### PR TITLE
Change DummyPowerManagement

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1013,8 +1013,6 @@
 			<true/>
 			<key>DisableRtcChecksum</key>
 			<true/>
-			<key>DummyPowerManagement</key>
-			<false/>
 			<key>ExtendBTFeatureFlags</key>
 			<false/>
 			<key>ExternalDiskIcons</key>


### PR DESCRIPTION
A partir de OC 6.2 ha sido movido a Emulate que lo tenías, pero no lo habias borrado de la otra zona. En mi caso he realizado este cambio pero sigue sin arrancar la instalación de Big Sur con esta versión de la EFI.